### PR TITLE
Refactor TaskSchema to avoid recursion errors, handle API response as array or object

### DIFF
--- a/app/serializer.py
+++ b/app/serializer.py
@@ -21,14 +21,11 @@ user_schema = UserSchema()
 users_schema = UserSchema(many=True)
 
 class TaskSchema(ma.SQLAlchemyAutoSchema):
-    errand_boy = fields.Nested('ErrandBoySchema')
-    category = fields.Nested('CategorySchema')
-    payment = fields.Nested('PaymentSchema')
-    user = fields.Nested('UserSchema')
     class Meta:
         model = Task
         load_instance = True
         include_fk = True
+        fields = ('id', 'description', 'location', 'status', 'user_id', 'errand_boy_id', 'category_id', 'estimated_time', 'completed_at')
 
 task_schema = TaskSchema()
 tasks_schema = TaskSchema(many=True)

--- a/client/src/components/UserUI/UserTasks.js
+++ b/client/src/components/UserUI/UserTasks.js
@@ -59,4 +59,5 @@ const UserTasks = () => {
   );
 };
 
+
 export default UserTasks;

--- a/client/src/components/UserUI/UserTasks.js
+++ b/client/src/components/UserUI/UserTasks.js
@@ -1,39 +1,62 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
+import { retrieve } from "../Encryption";
 
 const UserTasks = () => {
-    const [tasks, setTasks] = useState([]);
-    // Get user's id from local storage
-    const userId = localStorage.getItem('jwt');
+  const [tasks, setTasks] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
 
-    useEffect(() => {
-        // Fetch tasks from the Flask backend
-        axios.get(`/tasks/${userId}`, {
-            headers: {
-                'Authorization': `Bearer ${localStorage.getItem('jwt')}`,
-            },
-        })
-            .then(response => {
-                setTasks(response.data);
-            })
-            .catch(error => {
-                console.error('Error fetching tasks:', error);
-            });
-    }, [userId]);
+  const retrievedUser = retrieve();
+  const userId = retrievedUser ? retrievedUser.sub : null;
 
-    return (
-        <div className="content-wrapper" style={{ marginLeft: "280px", backgroundColor: "white", marginTop: "20px" }}>
-            <h1>User Tasks</h1>
-            {tasks.map(task => (
-                <div key={task.id}>
-                    <h2>{task.description}</h2>
-                    <p>Status: {task.status}</p>
-                    <p>Location: {task.location}</p>
-                    <p>Estimated Time: {task.estimated_time} </p>
-                </div>
-            ))}
-        </div>
-    );
+  useEffect(() => {
+    axios
+      .get(`/tasks/${userId}`, {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("jwt")}`,
+        },
+      })
+      .then((response) => {
+        console.log("Fetched tasks:", response.data);
+        // Check if the response is an array or a single object
+        const fetchedTasks = Array.isArray(response.data)
+          ? response.data
+          : [response.data];
+        setTasks(fetchedTasks);
+        setIsLoading(false);
+      })
+      .catch((error) => {
+        console.error("Error fetching tasks:", error);
+        setIsLoading(false);
+      });
+  }, [userId]);
+
+  return (
+    <div
+      className="content-wrapper"
+      style={{
+        marginLeft: "280px",
+        backgroundColor: "white",
+        marginTop: "20px",
+      }}
+    >
+      <h1>User Tasks</h1>
+      {isLoading ? (
+        <p>Loading tasks...</p>
+      ) : tasks && tasks.length > 0 ? (
+        tasks.map((task) => (
+          <div key={task.id}>
+            <h2>{task.description}</h2>
+            <p>Status: {task.status}</p>
+            <p>Location: {task.location}</p>
+            <p>Estimated Time: {task.estimated_time}</p>
+          </div>
+        ))
+      ) : (
+        <p>No tasks found.</p>
+      )}
+    </div>
+  );
 };
 
 export default UserTasks;


### PR DESCRIPTION
**Changes made**
- The API endpoint for fetching user tasks was returning a single task object instead of an array of tasks in some cases.
- This caused the "No tasks found" message to be displayed even when a task was present.
- To handle this scenario, the following changes were made:
1. In the 'useEffect' hook, after fetching the tasks from the API, check if the response data is an array using 'Array.isArray(response.data)'.
2. If the response data is an array, assign it to the 'fetchedTasks' variable.
3. If the response data is a single object, create a new array with that object and assign it to the 'fetchedTasks' variable.
4. Set the 'tasks' state with the 'fetchedTasks' variable to ensure that it's always an array.
- This change allows the component to correctly render tasks when the API returns a single task object or an array of tasks.
- If the API returns an empty array or no data, the "No tasks found" message will still be displayed.