### PR TITLE
feat: handle API response as array or object, use userId from retrieve

### DIFF
--- a/client/src/components/UserUI/UserRatings.js
+++ b/client/src/components/UserUI/UserRatings.js
@@ -1,22 +1,29 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
+import { retrieve } from "../Encryption";
 
 const UserRatings = () => {
     const [ratings, setRatings] = useState([]);
     const [error, setError] = useState(null);
     const [loading, setLoading] = useState(false);
-    const userId = localStorage.getItem('jwt');
+
+    const retrievedUser = retrieve(); // Get the retrieved user from the retrieve function
+    const userId = retrievedUser ? retrievedUser.sub : null; // Extract the user ID from the retrieved user
 
     useEffect(() => {
         setLoading(true);
         // Fetch ratings from the flask backend
-        axios.get(`/ratings/${userId}`, {
+        axios.get(`/rating/${userId}`, {
             headers: {
                 'Authorization': `Bearer ${localStorage.getItem('jwt')}`,
             },
         })
             .then(response => {
-                setRatings(response.data);
+                // Check if the response is an array or a single object
+                const fetchedRatings = Array.isArray(response.data)
+                    ? response.data
+                    : [response.data];
+                setRatings(fetchedRatings);
                 setLoading(false);
             })
             .catch(error => {


### PR DESCRIPTION
- This commit updates the 'UserRatings' component to handle the case where the API response is either an array of ratings or a single rating object.
- Additionally, it changes the implementation to use the user ID retrieved from the 'retrieve' function.
- Changes made:
1. Import the 'retrieve' function from the '../Encryption' module.
2. Call the 'retrieve' function and store the result in the 'retrievedUser' variable.
3. Extract the user ID from the 'retrievedUser' object using 'retrievedUser.sub' and store it in the 'userId' variable. If 'retrievedUser' is falsy, set 'userId' to 'null'.
4. Use the `userId` variable in the API endpoint URL: `/rating/${userId}` (note the singular 'rating' instead of 'ratings').
5. Remove the `userId` variable from the `useEffect` dependency array, as it is now derived from the `retrievedUser` object.
6. In the `then` block of the `useEffect` hook, check if `response.data` is an array using `Array.isArray(response.data)`.
7. If `response.data` is an array, assign it to the `fetchedRatings` variable.
8. If `response.data` is a single object, create a new array with that object and assign it to the `fetchedRatings` variable.
9. Set the `ratings` state with the `fetchedRatings` variable to ensure that it's always an array.

- With these changes, the `UserRatings` component will correctly render ratings when the API returns a single rating object or an array of ratings.
- It will also use the user ID retrieved from the `retrieve` function.