### PR TITLE
feat: handle API response as array or object, use userId from retrieve

### DIFF
--- a/client/src/components/UserUI/UserNotifications.js
+++ b/client/src/components/UserUI/UserNotifications.js
@@ -1,22 +1,29 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
+import { retrieve } from "../Encryption"; // Import the retrieve function
 
 const UserNotifications = () => {
     const [notifications, setNotifications] = useState([]);
     const [error, setError] = useState(null);
     const [loading, setLoading] = useState(false);
-    const userId = localStorage.getItem('jwt');
+
+    const retrievedUser = retrieve(); // Get the retrieved user from the retrieve function
+    const userId = retrievedUser ? retrievedUser.sub : null; // Extract the user ID from the retrieved user
 
     useEffect(() => {
         setLoading(true);
         // Fetch notifications from the flask backend
-        axios.get(`/notifications/${userId}`, {
+        axios.get(`/notification/${userId}`, {
             headers: {
                 'Authorization': `Bearer ${localStorage.getItem('jwt')}`,
             },
         })
             .then(response => {
-                setNotifications(response.data);
+                // Check if the response is an array or a single object
+                const fetchedNotifications = Array.isArray(response.data)
+                    ? response.data
+                    : [response.data];
+                setNotifications(fetchedNotifications);
                 setLoading(false);
             })
             .catch(error => {


### PR DESCRIPTION
- This commit updates the `UserNotifications` component to handle the case where the API response is either an array of notifications or a single notification object.
- Additionally, it changes the implementation to use the user ID retrieved from the `retrieve` function.

**Changes made:**
1. Import the `retrieve` function from the '../Encryption' module.
2. Call the `retrieve` function and store the result in the `retrievedUser` variable.
3. Extract the user ID from the `retrievedUser` object using `retrievedUser.sub` and store it in the `userId` variable. If `retrievedUser` is falsy, set `userId` to `null`.
4. Use the `userId` variable in the API endpoint URL: `/notification/${userId}` (note the singular 'notification' instead of 'notifications').
5. Remove the `userId` variable from the `useEffect` dependency array, as it is now derived from the `retrievedUser` object.
6. In the `then` block of the `useEffect` hook, check if `response.data` is an array using `Array.isArray(response.data)`.
7. If `response.data` is an array, assign it to the `fetchedNotifications` variable.
8. If `response.data` is a single object, create a new array with that object and assign it to the `fetchedNotifications` variable.
9. Set the `notifications` state with the `fetchedNotifications` variable to ensure that it's always an array.

- With these changes, the `UserNotifications` component will correctly render notifications when the API returns a single notification object or an array of notifications. 
- It will also use the user ID retrieved from the `retrieve` function, similar to the `UserTasks`, `UserRatings`, and `UserPayments` components.